### PR TITLE
Adjust nametag spawn height and update location calculations

### DIFF
--- a/src/main/java/com/lyttledev/lyttlenametag/handlers/NametagHandler.java
+++ b/src/main/java/com/lyttledev/lyttlenametag/handlers/NametagHandler.java
@@ -35,6 +35,7 @@ public class NametagHandler implements Listener {
     private final Map<UUID, NametagEntity> playerNametags = new ConcurrentHashMap<>();
     private final AtomicInteger entityIdCounter = new AtomicInteger(Integer.MAX_VALUE / 2);
     private BukkitTask timer;
+    private final double nametagSpawnHeight = 1.8; // Height above player's head for nametag
 
     public NametagHandler(LyttleNametag plugin) {
         this.plugin = plugin;
@@ -88,15 +89,17 @@ public class NametagHandler implements Listener {
         removeNametag(player);
 
         org.bukkit.Location baseLoc = player.getLocation().clone();
+        // Adjust the base location to be above the player's head
+        baseLoc.setY(baseLoc.getY() + nametagSpawnHeight); // Adjust height
         World world = baseLoc.getWorld();
 
         Replacements replacements = Replacements.builder()
                 .add("<PLAYER>", player.getName())
                 .add("<DISPLAYNAME>", player.displayName() != null ? player.displayName().toString() : player.getName())
                 .add("<WORLD>", world.getName())
-                .add("<X>", String.valueOf(player.getLocation().getBlockX()))
-                .add("<Y>", String.valueOf(player.getLocation().getBlockY()))
-                .add("<Z>", String.valueOf(player.getLocation().getBlockZ()))
+                .add("<X>", String.valueOf(baseLoc.getBlockX()))
+                .add("<Y>", String.valueOf(baseLoc.getBlockY()))
+                .add("<Z>", String.valueOf(baseLoc.getBlockZ()))
                 .build();
 
         String nametag = (String) plugin.config.general.get("nametag");
@@ -126,6 +129,10 @@ public class NametagHandler implements Listener {
         try {
             // Convert Bukkit Location to PacketEvents Location
             org.bukkit.Location bukkit_location = owner.getLocation().clone();
+
+            // Adjust the base location to be above the player's head
+            bukkit_location.setY(bukkit_location.getY() + nametagSpawnHeight); // Adjust height
+
             Location packetevents_location = new Location(
                     bukkit_location.getX(),
                     bukkit_location.getY(),

--- a/src/main/resources/#defaults/config.yml
+++ b/src/main/resources/#defaults/config.yml
@@ -13,7 +13,7 @@ nametag: |-
   <gray>%luckperms_prefix%
   <PLAYER></gray>
   <dark_gray>@</dark_gray>
-  <yellow>%vault_eco_balance_formatted%</yellow> <gold>Tokens</gold># Used internally for configuration updates.
+  <yellow>%vault_eco_balance_formatted%</yellow> <gold>Tokens</gold>
 
 # Interval in seconds for checking updates.
 interval: 60.0


### PR DESCRIPTION
This pull request improves the positioning accuracy of player nametags by ensuring they always appear above the player's head, regardless of the player's current location. The main changes focus on consistently using an adjusted Y-coordinate for nametag placement and updating the configuration file format.

**Nametag Positioning Improvements:**

* Added a `nametagSpawnHeight` constant to `NametagHandler` to define the height above the player's head for nametag placement.
* Updated the `spawnNametag` method to use `baseLoc.getY() + nametagSpawnHeight` when determining where to spawn the nametag, ensuring it appears above the player's head. Also, updated nametag coordinate replacements to use the adjusted location.
* Modified the `showNametagToPlayer` method to apply the same Y-offset when showing the nametag to viewers, keeping the nametag visually consistent.

**Configuration Cleanup:**

* Removed an unnecessary comment from the `nametag` line in `config.yml` to clean up the configuration file.