### PR TITLE
v1.2.4

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -94,7 +94,7 @@ jobs:
           HANGAR_API_TOKEN: ${{ secrets.HANGAR_API_TOKEN }}
           CHANNEL: ${{ github.ref_name == 'main' && 'Release' || 'Alpha' }}
         run: |
-          ./gradlew publishPluginJarToHangar -PjarPath=./dist/*.jar --stacktrace
+          ./gradlew hangarPublish --stacktrace
 
   publish-modrinth:
     needs: build-and-release
@@ -125,4 +125,4 @@ jobs:
           MODRINTH_API_TOKEN: ${{ secrets.MODRINTH_API_TOKEN }}
           CHANNEL: ${{ github.ref_name == 'main' && 'Release' || 'Alpha' }}
         run: |
-          ./gradlew publishPluginJarToModrinth -PjarPath=./dist/*.jar --stacktrace
+          ./gradlew modrinth --stacktrace


### PR DESCRIPTION
This pull request updates the release workflows, configuration migration, and plugin settings to improve artifact publishing and add a new configurable view distance for nametags. The changes modernize the CI/CD process, introduce a new config option, and ensure backward compatibility for existing users.

**CI/CD Workflow Improvements:**

- Refactored `.github/workflows/main.yml` and `.github/workflows/alpha.yml` to split the release process into separate jobs for building, releasing, and publishing to Hangar and Modrinth, and added steps to upload JAR artifacts and create GitHub releases. [[1]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L1-R86) [[2]](diffhunk://#diff-77705eb5ee9cd3186d976656ab5cd8d5177355a6a4f3631c004205b636830473L1-R86)

**Config and Migration Enhancements:**

- Added a new `view_distance` configuration option (default 64 blocks) to both `config.yml` and `#defaults/config.yml`, updated the config version to 3, and implemented migration logic to automatically add this option for users upgrading from previous config versions. [[1]](diffhunk://#diff-7b63c1703ad2ad2fd45bca45c4e0d120b974f46407da0cd17ae8ae4b048e256bR17-R26) [[2]](diffhunk://#diff-58cdd3d308ccba6c594e040ff9c065bb11eeb6e30f35ba87694ea45d5ae6096cR22-R26) [[3]](diffhunk://#diff-e3f55625c58389ac1a7178f3f0c0a48ccecfee966a413474e16ba527159187e6R89-R98)

**Nametag Feature Update:**

- Updated `NametagHandler` to use the new `view_distance` config value to control how far away nametags are visible, improving customization for server owners.

**Version Bump:**

- Increased `pluginVersion` to 1.2.4 in `gradle.properties` to reflect the new release.

**Code Cleanup:**

- Cleaned up imports in `NametagHandler.java` for better readability and maintainability.