### PR TITLE
v1.2.4

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Build project
         run: |
-          ./gradlew build --stacktrace \
+          ./gradlew shadowJar --stacktrace \
             -Pgpr.user="${GPR_USER}" \
             -Pgpr.key="${GPR_API_KEY}"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
     compileOnly("io.papermc.paper:paper-api:" + (property("paperVersion") as String) + "-R0.1-SNAPSHOT")
     compileOnly("me.clip:placeholderapi:2.11.6")
     compileOnly("com.github.retrooper:packetevents-spigot:2.9.4")
-    implementation("com.lyttledev:lyttleutils:1.1.7")
+    implementation("com.lyttledev:lyttleutils:1.2.0")
 }
 
 group = "com.lyttledev"

--- a/src/main/java/com/lyttledev/lyttlenametag/LyttleNametag.java
+++ b/src/main/java/com/lyttledev/lyttlenametag/LyttleNametag.java
@@ -92,7 +92,6 @@ public final class LyttleNametag extends JavaPlugin {
             case "2":
                 // Migrate config entries.
                 config.general.set("view_distance", config.defaultGeneral.get("view_distance"));
-                config.general.set("background_opacity", config.defaultGeneral.get("background_opacity"));
 
                 // Update config version.
                 config.general.set("config_version", 3);

--- a/src/main/java/com/lyttledev/lyttlenametag/LyttleNametag.java
+++ b/src/main/java/com/lyttledev/lyttlenametag/LyttleNametag.java
@@ -92,6 +92,7 @@ public final class LyttleNametag extends JavaPlugin {
             case "2":
                 // Migrate config entries.
                 config.general.set("view_distance", config.defaultGeneral.get("view_distance"));
+                config.general.set("background_opacity", config.defaultGeneral.get("background_opacity"));
 
                 // Update config version.
                 config.general.set("config_version", 3);

--- a/src/main/java/com/lyttledev/lyttlenametag/handlers/NametagHandler.java
+++ b/src/main/java/com/lyttledev/lyttlenametag/handlers/NametagHandler.java
@@ -217,12 +217,11 @@ public class NametagHandler implements Listener {
 
             // Set the text content of the text display entity
             Component text = entity.getText();
+            text = text.appendNewline();
             metadata.add(new EntityData<>(23, EntityDataTypes.ADV_COMPONENT, text));
 
             // Set background color to fully transparent
-            int backgroundOpacityConfig = (int) plugin.config.general.get("background_opacity");
-            int backgroundOpacity = backgroundOpacityConfig >= 0 && backgroundOpacityConfig <= 255 ? backgroundOpacityConfig : 80;
-            metadata.add(new EntityData<>(25, EntityDataTypes.INT, backgroundOpacity));
+            metadata.add(new EntityData<>(25, EntityDataTypes.INT, 0));
 
             WrapperPlayServerEntityMetadata metadataPacket = new WrapperPlayServerEntityMetadata(entityId, metadata);
 

--- a/src/main/java/com/lyttledev/lyttlenametag/handlers/NametagHandler.java
+++ b/src/main/java/com/lyttledev/lyttlenametag/handlers/NametagHandler.java
@@ -205,7 +205,9 @@ public class NametagHandler implements Listener {
             metadata.add(new EntityData<>(15, EntityDataTypes.BYTE, (byte) 0x03));
 
             float defaultViewDistance = 1.0f; // default (1 unit) equals 64 blocks
-            float blocksPerDefault = 64.0f;
+            // Tested: Default is 80 for our metadata.
+            // Default Minecraft client nametag distance is 64 blocks.
+            float blocksPerDefault = 80.0f;
             float oneBlockViewDistance = defaultViewDistance / blocksPerDefault;
 
             int blocksConfig = (int) plugin.config.general.get("view_distance");

--- a/src/main/java/com/lyttledev/lyttlenametag/handlers/NametagHandler.java
+++ b/src/main/java/com/lyttledev/lyttlenametag/handlers/NametagHandler.java
@@ -217,11 +217,12 @@ public class NametagHandler implements Listener {
 
             // Set the text content of the text display entity
             Component text = entity.getText();
-            text = text.appendNewline();
             metadata.add(new EntityData<>(23, EntityDataTypes.ADV_COMPONENT, text));
 
             // Set background color to fully transparent
-            metadata.add(new EntityData<>(25, EntityDataTypes.INT, 0));
+            int backgroundOpacityConfig = (int) plugin.config.general.get("background_opacity");
+            int backgroundOpacity = backgroundOpacityConfig >= 0 && backgroundOpacityConfig <= 255 ? backgroundOpacityConfig : 80;
+            metadata.add(new EntityData<>(25, EntityDataTypes.INT, backgroundOpacity));
 
             WrapperPlayServerEntityMetadata metadataPacket = new WrapperPlayServerEntityMetadata(entityId, metadata);
 

--- a/src/main/java/com/lyttledev/lyttlenametag/types/Configs.java
+++ b/src/main/java/com/lyttledev/lyttlenametag/types/Configs.java
@@ -1,30 +1,30 @@
 package com.lyttledev.lyttlenametag.types;
 
 import com.lyttledev.lyttlenametag.LyttleNametag;
-import com.lyttledev.lyttleutils.types.Config;
+import com.lyttledev.lyttleutils.types.YamlConfig;
 
 public class Configs {
     private final LyttleNametag plugin;
 
     // Configs
-    public Config general;
-    public Config messages;
+    public YamlConfig general;
+    public YamlConfig messages;
 
     // Default configs
-    public Config defaultGeneral;
-    public Config defaultMessages;
+    public YamlConfig defaultGeneral;
+    public YamlConfig defaultMessages;
 
 
     public Configs(LyttleNametag plugin) {
         this.plugin = plugin;
 
         // Configs
-        general = new Config(plugin, "config.yml");
-        messages = new Config(plugin, "messages.yml");
+        general = new YamlConfig(plugin, "config.yml");
+        messages = new YamlConfig(plugin, "messages.yml");
 
         // Default configs
-        defaultGeneral = new Config(plugin, "#defaults/config.yml");
-        defaultMessages = new Config(plugin, "#defaults/messages.yml");
+        defaultGeneral = new YamlConfig(plugin, "#defaults/config.yml");
+        defaultMessages = new YamlConfig(plugin, "#defaults/messages.yml");
     }
 
     public void reload() {

--- a/src/main/resources/#defaults/config.yml
+++ b/src/main/resources/#defaults/config.yml
@@ -22,8 +22,5 @@ interval: 0.5
 # The maximum distance at which the nametag will be visible. (In blocks) (default: 64)
 view_distance: 64
 
-# Background opacity (0-100). 0 = fully transparent, 100 = fully opaque. (default: 80)
-background_opacity: 80
-
 # ⚠️ Do not change this value.
 config_version: 3

--- a/src/main/resources/#defaults/config.yml
+++ b/src/main/resources/#defaults/config.yml
@@ -19,8 +19,11 @@ nametag: |-
 # Interval in seconds for checking updates.
 interval: 0.5
 
-# The maximum distance at which the nametag will be visible. (In blocks)
+# The maximum distance at which the nametag will be visible. (In blocks) (default: 64)
 view_distance: 64
+
+# Background opacity (0-100). 0 = fully transparent, 100 = fully opaque. (default: 80)
+background_opacity: 80
 
 # ⚠️ Do not change this value.
 config_version: 3

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -19,7 +19,7 @@ nametag: |-
 # Interval in seconds for checking updates.
 interval: 0.5
 
-# The maximum distance at which the nametag will be visible. (In blocks)
+# The maximum distance at which the nametag will be visible. (In blocks) (default: 64)
 view_distance: 64
 
 # ⚠️ Do not change this value.

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -22,8 +22,5 @@ interval: 0.5
 # The maximum distance at which the nametag will be visible. (In blocks) (default: 64)
 view_distance: 64
 
-# Background opacity (0-100). 0 = fully transparent, 100 = fully opaque. (default: 80)
-background_opacity: 80
-
 # ⚠️ Do not change this value.
 config_version: 3

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -22,5 +22,8 @@ interval: 0.5
 # The maximum distance at which the nametag will be visible. (In blocks) (default: 64)
 view_distance: 64
 
+# Background opacity (0-100). 0 = fully transparent, 100 = fully opaque. (default: 80)
+background_opacity: 80
+
 # ⚠️ Do not change this value.
 config_version: 3


### PR DESCRIPTION
This pull request updates the configuration system and nametag view distance handling in the project. The most significant changes are the migration to a new configuration class and clarification of the view distance logic to better match Minecraft client behavior.

**Configuration system migration:**

* Replaced usage of the `Config` class with `YamlConfig` for all configuration files in `Configs.java`, updating both active and default configs to use the new class.

**Nametag view distance handling:**

* Updated the calculation in `NametagHandler.java` to use a default value of 80 for `blocksPerDefault`, reflecting the actual metadata used, and clarified the difference from the Minecraft client default of 64 blocks.
* Updated comments in both `config.yml` and `#defaults/config.yml` to clarify that the default maximum nametag view distance is 64 blocks.

**Build and workflow improvements:**

* Changed the build command in the GitHub Actions workflow from `./gradlew build` to `./gradlew shadowJar` to produce a fat JAR for releases.