### PR TITLE
v1.3.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,8 +32,8 @@ repositories {
 dependencies {
     compileOnly("io.papermc.paper:paper-api:" + (property("paperVersion") as String) + "-R0.1-SNAPSHOT")
     compileOnly("me.clip:placeholderapi:2.11.6")
-    implementation("com.github.retrooper:packetevents-spigot:2.9.5")
-    implementation("com.lyttledev:lyttleutils:1.2.0")
+    implementation("com.github.retrooper:packetevents-spigot:2.12.0")
+    implementation("com.lyttledev:lyttleutils:1.2.1")
 }
 
 group = "com.lyttledev"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # The current version of the plugin.
-pluginVersion=1.3.0
+pluginVersion=1.3.1
 
 # Specify the platform versions for Paper, Velocity, and Waterfall.
 # Hangar also allows version ranges (such as 1.19-1.20.2) and wildcards (such as 1.20.x).
-paperVersion=1.21.8
+paperVersion=1.21.11

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,6 @@
+#Thu Apr 09 22:23:54 CEST 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
-networkTimeout=10000
-validateDistributionUrl=true
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This pull request updates the build tooling and dependencies to keep the project up-to-date and compatible with recent versions. The main changes are version bumps for the plugin, Paper platform, and Gradle itself.

Dependency and tooling updates:

* Bumped the `pluginVersion` from `1.3.0` to `1.3.1` and updated the `paperVersion` from `1.21.8` to `1.21.11` in `gradle.properties` to ensure compatibility with the latest Paper server releases.
* Upgraded the Gradle wrapper from version `8.11.1` to `8.14.4` in `gradle/wrapper/gradle-wrapper.properties` to use the latest Gradle features and bug fixes.